### PR TITLE
Update minimum versions of dependencies

### DIFF
--- a/eslint-config/package.json
+++ b/eslint-config/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "eslint": "^8.34.0",
-    "prettier": "^2.8.4"
+    "eslint": "^8.49.0",
+    "prettier": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@tree-company/eslint-config": "^0.2.1",
     "eslint": "^8.49.0",
-    "prettier": "^2.8.8"
+    "prettier": "^3.0.3"
   },
   "eslintConfig": {
     "extends": [

--- a/stylelint-config/package.json
+++ b/stylelint-config/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "prettier": "^2.8.4",
-    "stylelint": "^15.2.0"
+    "prettier": "^3.0.3",
+    "stylelint": "^15.10.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,10 +1487,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 prop-types@^15.8.1:
   version "15.8.1"


### PR DESCRIPTION
This PR updates the minimum required versions of all our dependencies.
This mostly switches prettier to v3.0.x