### PR TITLE
Allow global modifiers in BEM pattern

### DIFF
--- a/stylelint-config/rules/selector_class_pattern.js
+++ b/stylelint-config/rules/selector_class_pattern.js
@@ -1,6 +1,18 @@
 module.exports = {
   BEMPattern: [
-    /^[a-z]+(:)?[a-z]+-?[a-z]*(__[0-9a-z]+-?[0-9a-z]*)?(--[0-9a-z]+-?[a-z]*)?$/,
+    /**
+     * This allows BEM classes with global modifiers
+     * ```css
+     * .block {}
+     * .some-block {}
+     * .block--modifier {}
+     * .block__element {}
+     * .block__some-element {}
+     * .block__element--modifier {}
+     * .--global-modifier {}
+     * ```
+     */
+    /^([a-z]+(:)?[a-z]+-?[a-z]*)?(__[0-9a-z]+-?[0-9a-z]*)?(--[0-9a-z]+-?[a-z]*)?$/,
     {
       resolveNestedSelectors: true,
       message: "Expected class selector to be BEM-style",


### PR DESCRIPTION
## Summary of changes
We allow global modifiers in BEM naming from now on. Global modifiers are utility classes that would be handy if there is a pattern that occurs often:
```css
.--hide {
  display: none;
}

@media (screen and (min-width: 1024px)) {
  .--hide-lg {
    display: none;
  }
  
  .--show-lg {
    display: unset;
  }
}
```

It can be tempting to do a lot of things with global modifiers, but this should really only be used if you end up repeating the same modifier across a bunch of blocks and/or elements.

For example, if your classes show/hide a lot of stuff depending on breakpoints
```css
.header__logo--hide-lg {}
.header__logo--show-lg {}
.form__submit--hide-lg {}
.form__submit--show-lg {}
.hero-image--hide-lg {}
.hero-image--show-lg {}
```

It could make sense to rework your html to use global modifiers.

## Checklist
<!---
  Before requesting a review, make sure to go over this checklist
  and verify that everything is ok.
  --->
- [x] All CI checks are working
<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
