### PR TITLE
Disable `noreferrer` rule from React

### DIFF
--- a/eslint-config/index.js
+++ b/eslint-config/index.js
@@ -45,6 +45,8 @@ const reactConfig = [
     },
     rules: {
       "react/prop-types": 0,
+      // noreferrer not needed in modern browsers https://github.com/jsx-eslint/eslint-plugin-react/issues/3672
+      "react/jsx-no-target-blank": "off",
     },
   },
 ];


### PR DESCRIPTION
<!---
  Choose a good and short sentence as the title of your PR.
  This should be an imperative command, eg. `Allow admin ...`
  --->

The addition of `rel="noreferrer"` on lint fixes comes from React eslint config.
However it is no longer needed in modern browsers, so the extra attributes can be safely removed and reduce noise in the HTML.
See https://github.com/jsx-eslint/eslint-plugin-react/issues/3672

On local testing, this change will leave previous `rel` attributes untouched, and won't remove them on consequent lint fixes, so our repos won't suddenly have noisy diffs.


## Summary of changes
<!---
  Please include a summary of the change and which issue is
  fixed. Please also include relevant motivation and context.
  --->


## Checklist
<!---
  Before requesting a review, make sure to go over this checklist
  and verify that everything is ok.
  --->
- [x] All CI checks are working
- [ ] I've added tests relevant to my changes.
- [ ] I've added documentation relevant to my changes.
- [ ] I've moved all hardcoded copy to translations
<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
